### PR TITLE
Fix quotes in multiline option

### DIFF
--- a/doxygen/configParser.py
+++ b/doxygen/configParser.py
@@ -11,7 +11,7 @@ class ConfigParser:
 
     def __init__(self):
         self.__single_line_option_regex = re.compile("^\s*(\w+)\s*=\s*([^\\\\]*)\s*$")
-        self.__first_line_of_multine_option_regex = re.compile("^\s*(\w+)\s*=\s*(.*)\\\\$")
+        self.__first_line_of_multine_option_regex = re.compile("^\s*(\w+)\s*=\s*(|.*[^\s])\s*\\\\$")
 
     def load_configuration(self, doxyfile: str) -> dict:
         """

--- a/doxygen/configParser.py
+++ b/doxygen/configParser.py
@@ -45,7 +45,8 @@ class ConfigParser:
                     if not line.endswith('\\'):
                         in_multiline_option = False
                     option_value = line.rstrip('\\').strip()
-                    configuration[current_multiline_option_name].append(option_value)
+                    unquoted_option_value = self.__remove_double_quote_if_required(option_value)
+                    configuration[current_multiline_option_name].append(unquoted_option_value)
 
                 elif self.__is_first_line_of_multiline_option(line):
                     current_multiline_option_name, option_value = self.__extract_multiline_option_name_and_first_value(line)

--- a/tests/test_doxygenConfigParser.py
+++ b/tests/test_doxygenConfigParser.py
@@ -73,6 +73,15 @@ class DoxygenConfigParserTest(unittest.TestCase):
 
         self.assertEqual(['line1', 'line2', 'line3'], configuration['MULTILINE_OPTION'])
 
+    def test_quoted_multiline_option(self):
+        configuration = self.get_configuration_from_lines([
+            'MULTILINE_OPTION = "line 1" \\',
+            '                   "line 2" \\',
+            '                   "line 3"',
+        ])
+
+        self.assertEqual(['line 1', 'line 2', 'line 3'], configuration['MULTILINE_OPTION'])
+
     def get_configuration_from_lines(self, lines: List[str]) -> dict:
         """Writes lines into a Doxyfile and reads it. This will also write and load the configuration again to check if
         the config_parser changes it

--- a/tests/test_doxygenConfigParser.py
+++ b/tests/test_doxygenConfigParser.py
@@ -1,7 +1,7 @@
 import logging
-import unittest
-
 import os
+import unittest
+from typing import List
 
 from doxygen import ConfigParser
 
@@ -13,6 +13,7 @@ class DoxygenConfigParserTest(unittest.TestCase):
         logging.disable(logging.CRITICAL)
         self.doxyfile_original = os.path.join(os.path.dirname(__file__), "assets/Doxyfile")
         self.doxyfile_working = "./Doxyfile.tmp"
+        self.doxyfile_clone = "./Cloned_Doxyfile.tmp"
 
     def test_try_use_not_existing_doxyfile(self):
         config_parser = ConfigParser()
@@ -21,6 +22,9 @@ class DoxygenConfigParserTest(unittest.TestCase):
     def tearDown(self):
         if os.path.exists(self.doxyfile_working):
             os.remove(self.doxyfile_working)
+
+        if os.path.exists(self.doxyfile_clone):
+            os.remove(self.doxyfile_clone)
 
     def test_load_configuration(self):
         config_parser = ConfigParser()
@@ -50,6 +54,38 @@ class DoxygenConfigParserTest(unittest.TestCase):
         self.assertEqual(configuration_updated['PROJECT_NAME'], 'something cool')
         self.assertEqual(configuration_updated['PROJECT_NUMBER'], '1.2.3.4')
         self.assertTrue("*.dtc" in configuration_updated['FILE_PATTERNS'])
+
+    def test_multiline_option_with_empty_lines(self):
+        configuration = self.get_configuration_from_lines([
+            'MULTILINE_OPTION = \\',
+            '                   \\',
+            '                   line3',
+        ])
+
+        self.assertEqual(['', '', 'line3'], configuration['MULTILINE_OPTION'])
+
+    def test_multiline_option(self):
+        configuration = self.get_configuration_from_lines([
+            'MULTILINE_OPTION = line1 \\',
+            '                   line2 \\',
+            '                   line3',
+        ])
+
+        self.assertEqual(['line1', 'line2', 'line3'], configuration['MULTILINE_OPTION'])
+
+    def get_configuration_from_lines(self, lines: List[str]) -> dict:
+        """Writes lines into a Doxyfile and reads it. This will also write and load the configuration again to check if
+        the config_parser changes it
+        """
+        with open(self.doxyfile_working, 'w') as io:
+            io.write('\n'.join(lines))
+
+        parser = ConfigParser()
+        configuration = parser.load_configuration(self.doxyfile_working)
+        parser.store_configuration(configuration, self.doxyfile_clone)
+        other_configuration = parser.load_configuration(self.doxyfile_clone)
+        self.assertEqual(configuration, other_configuration)
+        return configuration
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
See issue #8 (this also includes the commit of issue #9 the reason for this is that it reuses its tests)